### PR TITLE
Adds default user to adding produceFormData object for testing purposes

### DIFF
--- a/client/src/components/addProductTest.js
+++ b/client/src/components/addProductTest.js
@@ -20,6 +20,7 @@ export default function Upload() {
         productAvailability: '',
         productDescription: '',
         productImage: '',
+        user: '64404cdddab04f21017abbd2'
     });
 
     const [loading, setLoading] = useState(false);
@@ -46,7 +47,7 @@ export default function Upload() {
             .post("http://localhost:3000/uploadImage", { image: base64 })
             .then((res) => {
                 setUrl(res.data);
-                alert(`Image uploaded Succesfully. Url is ${url}`);
+                alert(`Image uploaded Successfully.`);
             })
             .then(() => setLoading(false))
             .catch(console.log);
@@ -122,6 +123,7 @@ export default function Upload() {
                     productAvailability: productFormData.productAvailability,
                     productDescription: productFormData.productDescription,
                     productImage: url,
+                    user: productFormData.user
                 },
             });
             return data;

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -2,8 +2,8 @@
 import { gql } from '@apollo/client';
 
 export const ADD_PRODUCT = gql`
-mutation Mutation($productId: Int!, $productName: String!, $productType: Boolean!, $productPrice: Float!, $productImage: String, $productDescription: String, $productAllergens: String, $productUnits: String, $productInventory: Int, $productCategory: String, $productAvailability: Boolean) {
-  addProduct(productId: $productId, productName: $productName, productType:$productType, productPrice: $productPrice, productImage: $productImage, productDescription: $productDescription, productAllergens: $productAllergens, productUnits: $productUnits, productInventory: $productInventory, productCategory: $productCategory, productAvailability: $productAvailability) {
+mutation Mutation($productId: Int!, $productName: String!, $productPrice: Float!, $productType: Boolean, $productCategory: String, $productInventory: Int, $productUnits: String, $productAllergens: String, $productAvailability: Boolean, $productDescription: String, $productImage: String, $user: [ID]!) {
+  addProduct(productId: $productId, productName: $productName, productPrice: $productPrice, productType: $productType, productCategory: $productCategory, productInventory: $productInventory, productUnits: $productUnits, productAllergens: $productAllergens, productAvailability: $productAvailability, productDescription: $productDescription, productImage: $productImage, user: $user){ 
     productId
     productName
     productType
@@ -15,6 +15,7 @@ mutation Mutation($productId: Int!, $productName: String!, $productType: Boolean
     productAvailability
     productDescription
     productImage
+    _id #for user
   }
 }
 `;


### PR DESCRIPTION
In response to the previous PR where the addProduct resolvers function includes a user to add, this update adds a default user to the productFormData object in addProductTest.js. This allows the form to remain functional. 

For others that wish to use this branch, change the user's ObjectId on line 23 to any of your local MongoDB User's ObjectId.