### PR TITLE
Requires users to login before adding items

### DIFF
--- a/client/src/components/Cart.js
+++ b/client/src/components/Cart.js
@@ -7,6 +7,7 @@ import CartItem from '../components/CartItems';
 import Auth from '../utils/auth';
 import { useProductContext } from '../utils/GlobalState';
 import { TOGGLE_CART, ADD_MULTIPLE_TO_CART, CLEAR_CART } from '../utils/actions';
+import { Link } from "react-router-dom";
 // import './style.css';
 
 // Sample public testing key for stripe
@@ -115,14 +116,9 @@ const Cart = () => {
                                     <div className="modal-footer">
                                         <button type="button" className="btn btn-secondary" data-bs-dismiss="modal">Add items</button>
                                         <button type="button" className="btn btn-secondary" onClick={clearCart}>Clear Cart</button>
-                                        {Auth.loggedIn() ? (
                                             <form action="/create-checkout-session" method="POST">
                                                 <button type="button" className="btn btn-secondary" onClick={submitCheckout}>Checkout</button>
                                             </form>
-                                        ) : (
-                                            <span>(log in to check out)</span>
-                                        )}
-
                                     </div>
                                 </div>
                             ) : (
@@ -134,12 +130,7 @@ const Cart = () => {
                     </div>
                 </div>
             </div>
-
         </div>
-
-
-
-
     );
 };
 

--- a/client/src/components/ProductSingleOther.js
+++ b/client/src/components/ProductSingleOther.js
@@ -1,9 +1,10 @@
 import React from "react";
-// import { Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 // import { pluralize } from "../../utils/helpers"
 import { useProductContext } from "../utils/GlobalState";
 import { ADD_TO_CART, UPDATE_CART_QUANTITY } from "../utils/actions";
 import { idbPromise } from "../utils/helpers";
+import Auth from '../utils/auth';
 
 
 function ProductSingleOther(item) {
@@ -71,11 +72,17 @@ function ProductSingleOther(item) {
                     </div>
 
                     <div className="input-group input-group-sm mb-3">
-                        <button className="btn btn-outline-secondary" type="button" onClick={addToCart}>Add to cart</button>
+                        {Auth.loggedIn() ? (
+                            <button className="btn btn-outline-secondary" type="button" onClick={addToCart}>Add to cart</button>
+                        ) : (
+                            <Link to="/login">
+                                <button className="btn btn-outline-secondary" type="button">Login to add</button>
+                            </Link>
+                        )}
                     </div>
                 </div>
             </div>
-        </div>
+        </div >
     );
 }
 


### PR DESCRIPTION
This update requires users to login before adding items, as opposed to having the users fill up carts only to have them be deleted while redirected to the login page.