### PR TITLE
Claire fixes in cart bug 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,4 @@ Credit for utilizing several activities in George Washington University Coding B
 19. [Receiving timestamp on date return from MongoDB](https://stackoverflow.com/questions/74724711/mongodb-query-dates-returning-as-string-of-numbers)
 20. [Converting timestamp to MM/DD/YYYY formate with .toLocaleDateString('en-US') method](https://bobbyhadz.com/blog/javascript-convert-milliseconds-to-date)
 21. [Finding sum of an array](https://reqbin.com/code/javascript/m81eb1ms/javascript-sum-array-example)
+22. [Using React State to count clicks on a button](https://github.com/Ebazhanov/click-counter)

--- a/client/src/components/CartItems.js
+++ b/client/src/components/CartItems.js
@@ -71,7 +71,7 @@ const CartItem = ({ item }) => {
                                 className='ms-2'
                                 type="number"
                                 placeholder=""
-                                defaultValue={item.purchaseQuantity}
+                                value={item.purchaseQuantity}
                                 onChange={onChange}
                             />
                         </div>

--- a/client/src/components/ProductSingleOther.js
+++ b/client/src/components/ProductSingleOther.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 // import { pluralize } from "../../utils/helpers"
 import { useProductContext } from "../utils/GlobalState";
@@ -27,18 +27,21 @@ function ProductSingleOther(item) {
 
     const { cart, vendorStatus } = state
 
-    const addToCart = () => {
+    const [value, setValue] = useState(1)
+    const addToCart = (e) => {
+        e.preventDefault()
+
+        setValue(value + 1);
+
         const itemInCart = cart.find((cartItem) => cartItem._id === _id)
         if (itemInCart) {
             dispatch({
                 type: UPDATE_CART_QUANTITY,
                 _id: _id,
-                purchaseQuantity: parseInt(itemInCart.purchaseQuantity) + 1
+                purchaseQuantity: parseInt(value)
             });
-            idbPromise('cart', 'put', {
-                ...itemInCart,
-                purchaseQuantity: parseInt(itemInCart.purchaseQuantity) + 1
-            });
+            idbPromise('cart', 'put', { ...itemInCart, purchaseQuantity: parseInt(value) });
+            console.log(state)
         } else {
             dispatch({
                 type: ADD_TO_CART,


### PR DESCRIPTION
This update fixes the issue where clicking "Add to Cart" for a store's product card multiple times does not update the value of the input form for the in-cart modal, despite the subtotal being correct when multiplying the price with the number of clicks. 

Now, when you click "Add to Cart 3 times on the product card, the Cart modal's input form group will say that there are 3 items.


HOWEVER, there is another issue now. Lets say you click "Add to cart" 3 times for broccoli. You open cart modal and change broccoli to 2 and closed the modal to add more items. Someone told you to get another broccoli, so you click "Add to cart" on the broccoli card once more, you would expect the quantity in cart to be 3 ( 3 - 1 + 1  = 3), however, you'd be getting 4 in the cart. This is because made a function that counted the number of clicks on the "add to cart" button, set it to a state called value, and sent that value to the purchaseQuantity property in global state. The number of times the button has been clicked was 3. Another click, makes it 4. So the function makes the quantity value set to 4 in the in-cart modal. 