### PR TITLE
Masandra fixes vendorAddress rendering in Orders History

### DIFF
--- a/client/src/components/signupForm/SignupForm.js
+++ b/client/src/components/signupForm/SignupForm.js
@@ -433,10 +433,11 @@ function Signup(props) {
                                 :
                                 <button className="btn btn-secondary signup-pg-btns mt-2" type="submit" id="signup-btn">Submit</button>
                             }
-                            < Link to="/login">
+                            {/* Zhihao approved to remove login button on the Signup modal - can cause user error clicking this instead of signup button */}
+                            {/* < Link to="/login">
                                 <button id="login-btn" className="btn btn-secondary signup-pg-btns mt-2 ms-3" type="button" >
                                     Login</button>
-                            </Link>
+                            </Link> */}
                         </div>
                     </form>
 

--- a/client/src/pages/OrderHistory.js
+++ b/client/src/pages/OrderHistory.js
@@ -14,23 +14,17 @@ import ConsumerOrder from '../components/orderhistory/consumerOrder';
 import VendorOrder from '../components/orderhistory/vendorOrder';
 import { useQuery } from '@apollo/client'
 import { useParams } from 'react-router-dom';
-import { QUERY_SINGLE_PROFILE, GET_ME } from '../utils/queries'
+import { GET_ME } from '../utils/queries'
 
 const OrderHistory = () => {
     const [filteredOrders, setFilteredOrders] = useState([]);
     const [filteredOrdersByVendor, setFilteredOrdersByVendor] = useState([]);
 
-    const { profileId } = useParams();
     //if params that pass in userID exist, use QUERY_SINGLE_PROFILE, if not, use GET_ME query
-    const { loading, error, data } = useQuery(
-        profileId ? QUERY_SINGLE_PROFILE : GET_ME,
-        {
-            variables: { profileId: profileId },
-        },
-    );
+    const { loading, error, data } = useQuery(GET_ME);
 
     console.log(data);
-    const profile = data?.me || data?.profile || {};
+    const profile = data?.me || {};
 
     const userOrder = profile.orders
     const userSales = profile.sales

--- a/client/src/pages/Success.js
+++ b/client/src/pages/Success.js
@@ -75,7 +75,7 @@ function Success() {
                 window.location.assign('/');
                 localStorage.clear();
                 console.log("Delayed by example 1000 = 1 second")
-            }, 10000000);
+            }, 4000);
         }
 
         saveOrder();

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -207,6 +207,8 @@ query me {
         firstName
         lastName
         userImage
+        phone
+        email
       }
       sellerName {
         _id

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -25,7 +25,13 @@ const resolvers = {
                     })
                     .populate({
                         path: 'orders',
-                        populate: ['products', 'buyerName', 'sellerName']
+                        populate: [
+                            'products', 'buyerName', 
+                            {
+                                path: 'sellerName',
+                                populate: 'pickupAddress',
+                            },
+                        ]
                     })
                     .populate('address')
                     .populate('vendorAddress')

--- a/server/seeds/seeds.js
+++ b/server/seeds/seeds.js
@@ -1273,7 +1273,7 @@ db.once('open', async () => {
             zipcode: '22033',
         },
         {
-            street: '7101 Democracy Blvd, Bethesda',
+            street: '7101 Democracy Blvd',
             city: 'Bethesda',
             state: 'Maryland',
             zipcode: '20817',


### PR DESCRIPTION
Solution: resolver file - Great grandchild of me for vendorAddress under the Orders objects needed to have their own populate path code.

Also with this PR:
- Seed fix for city repeating in one of the seeds
- set timeout at success page reduced to 4 seconds since done with testing
- removed the profile query in orderhistory (not needed since we are only using ME query and not providing any params)
- remove log in button on the sign up modal to prevent user error
- added contact details (email, phone number) for the buyer in case the seller needs to contact the buyer